### PR TITLE
Add gradle plugin descriptor

### DIFF
--- a/kotlin-ir-plugin-gradle/build.gradle.kts
+++ b/kotlin-ir-plugin-gradle/build.gradle.kts
@@ -23,3 +23,14 @@ buildConfig {
 tasks.withType<KotlinCompile> {
   kotlinOptions.jvmTarget = "1.8"
 }
+
+gradlePlugin {
+  plugins {
+    create("kotlinIrPluginTemplate") {
+      id = rootProject.extra["kotlin_plugin_id"] as String
+      displayName = "Kotlin Ir Plugin Template"
+      description = "Kotlin Ir Plugin Template"
+      implementationClass = "com.bnorm.template.TemplateGradlePlugin"
+    }
+  }
+}


### PR DESCRIPTION
Adds a descriptor for the gradle plugin.  This is required for publishing and usage (even in an included build if you use the `plugins` block).