### PR TITLE
Remove explicit dependency on the kotlin-stdlib

### DIFF
--- a/kotlin-ir-plugin-gradle/build.gradle.kts
+++ b/kotlin-ir-plugin-gradle/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 dependencies {
-  implementation(kotlin("stdlib"))
   implementation(kotlin("gradle-plugin-api"))
 }
 


### PR DESCRIPTION
Starting with Kotlin 1.4, the dependency on the standard library is [added by default](https://kotlinlang.org/docs/whatsnew14.html#dependency-on-the-standard-library-added-by-default).