### PR TITLE
Remove explicit setting of JVM target

### DIFF
--- a/kotlin-ir-plugin-gradle/build.gradle.kts
+++ b/kotlin-ir-plugin-gradle/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   id("java-gradle-plugin")
   kotlin("jvm")
@@ -17,10 +15,6 @@ buildConfig {
   buildConfigField("String", "KOTLIN_PLUGIN_GROUP", "\"${project.group}\"")
   buildConfigField("String", "KOTLIN_PLUGIN_NAME", "\"${project.name}\"")
   buildConfigField("String", "KOTLIN_PLUGIN_VERSION", "\"${project.version}\"")
-}
-
-tasks.withType<KotlinCompile> {
-  kotlinOptions.jvmTarget = "1.8"
 }
 
 gradlePlugin {

--- a/kotlin-ir-plugin-native/build.gradle.kts
+++ b/kotlin-ir-plugin-native/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   kotlin("jvm")
   kotlin("kapt")
@@ -24,8 +22,4 @@ tasks.register<Sync>("syncSource") {
       else -> it
     }
   }
-}
-
-tasks.withType<KotlinCompile> {
-  kotlinOptions.jvmTarget = "1.8"
 }

--- a/kotlin-ir-plugin/build.gradle.kts
+++ b/kotlin-ir-plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
   kotlin("jvm")
   kotlin("kapt")
@@ -20,8 +18,4 @@ dependencies {
 buildConfig {
   packageName(group.toString())
   buildConfigField("String", "KOTLIN_PLUGIN_ID", "\"${rootProject.extra["kotlin_plugin_id"]}\"")
-}
-
-tasks.withType<KotlinCompile> {
-  kotlinOptions.jvmTarget = "1.8"
 }


### PR DESCRIPTION
Starting with Kotlin 1.5, the [new default JVM target is 1.8](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), so we don't have to explicitly specify it anymore.