### PR TITLE
Update template to Kotlin 2.0.20

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@ buildscript {
 }
 
 plugins {
-  kotlin("jvm") version "1.9.22" apply false
-  id("org.jetbrains.dokka") version "1.9.10" apply false
+  kotlin("jvm") version "2.0.20" apply false
+  id("org.jetbrains.dokka") version "1.9.20" apply false
   id("com.gradle.plugin-publish") version "1.2.1" apply false
-  id("com.github.gmazzo.buildconfig") version "5.3.5" apply false
+  id("com.github.gmazzo.buildconfig") version "5.5.0" apply false
 }
 
 allprojects {

--- a/kotlin-ir-plugin/build.gradle.kts
+++ b/kotlin-ir-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 
   testImplementation(kotlin("test-junit"))
   testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable")
-  testImplementation("dev.zacsweers.kctfork:core:0.4.0")
+  testImplementation("dev.zacsweers.kctfork:core:0.5.1")
 }
 
 buildConfig {


### PR DESCRIPTION
I updated the dependencies to work with Kotlin 2.0.20.

I did a quick test of syntax that is only available in Kotlin >= 2.0.0 and it worked.